### PR TITLE
Capture and add warnings separately in AnalyticResult from standard error in analytic results

### DIFF
--- a/spotfire/data_function.py
+++ b/spotfire/data_function.py
@@ -12,6 +12,7 @@ import traceback
 import types
 import typing
 import re
+import warnings
 
 from spotfire import sbdf, _utils
 
@@ -25,6 +26,7 @@ _LogFunction = typing.Callable[[str], None]
 
 
 _COLUMN_METADATA_TRUNCATE_THRESHOLD = 80000
+_MAX_WARNINGS = 100
 
 
 def _bad_string(str_: typing.Any) -> bool:
@@ -220,7 +222,9 @@ class AnalyticOutput:
 
 class AnalyticResult:
     """Represents the results of evaluating an AnalyticSpec object."""
+    # pylint: disable=too-many-instance-attributes
     std_err_out: typing.Optional[str]
+    warnings: list[str]
     summary: typing.Optional[str]
     _exc_info: _ExceptionInfo
     _debug_log: typing.Optional[str]
@@ -228,7 +232,9 @@ class AnalyticResult:
     def __init__(self, capture: _OutputCapture) -> None:
         self.success = True
         self.has_stderr = False
+        self.has_warnings = False
         self.std_err_out = None
+        self.warnings = []
         self.summary = None
         self._exc_info = (None, None, None)
         self._capture = capture
@@ -413,9 +419,20 @@ class AnalyticSpec:
         if self.analytic_type == "script":
             # noinspection PyBroadException
             try:
-                exec(compiled_script, self.globals)
+                with warnings.catch_warnings(record=True) as caught_warnings:
+                    exec(compiled_script, self.globals)
             except BaseException:
                 result.fail_with_exception(sys.exc_info())
+            if caught_warnings:
+                result.has_warnings = True
+                total = len(caught_warnings)
+                result.warnings = [
+                    warnings.formatwarning(w.message, w.category, w.filename, w.lineno, w.line)
+                    for w in caught_warnings[:_MAX_WARNINGS]
+                ]
+                if total > _MAX_WARNINGS:
+                    result.warnings.append(f"... and {total - _MAX_WARNINGS} more warnings (truncated)\n")
+            if not result.success:
                 return
         elif self.analytic_type == "aggregationScript":
             self.debug("aggregation scripts are not supported")
@@ -489,6 +506,9 @@ class AnalyticSpec:
                     result.has_stderr = True
                     buf.write("\nStandard error:\n")
                     buf.write(result.std_err_out)
+            if result.has_warnings:
+                buf.write("\nWarnings:\n")
+                buf.writelines(result.warnings)
             if self.debug_enabled:
                 debug_log = result.get_debug_log()
                 if debug_log:

--- a/spotfire/data_function.py
+++ b/spotfire/data_function.py
@@ -426,12 +426,17 @@ class AnalyticSpec:
             if caught_warnings:
                 result.has_warnings = True
                 total = len(caught_warnings)
-                result.warnings = [
-                    warnings.formatwarning(w.message, w.category, w.filename, w.lineno, w.line)
-                    for w in caught_warnings[:_MAX_WARNINGS]
-                ]
                 if total > _MAX_WARNINGS:
-                    result.warnings.append(f"... and {total - _MAX_WARNINGS} more warnings (truncated)\n")
+                    result.warnings = [
+                        warnings.formatwarning(w.message, w.category, w.filename, w.lineno, w.line)
+                        for w in caught_warnings[:_MAX_WARNINGS - 1]
+                    ]
+                    result.warnings.append(f"... and {total - _MAX_WARNINGS + 1} more warnings (truncated)\n")
+                else:
+                    result.warnings = [
+                        warnings.formatwarning(w.message, w.category, w.filename, w.lineno, w.line)
+                        for w in caught_warnings
+                    ]
             if not result.success:
                 return
         elif self.analytic_type == "aggregationScript":

--- a/spotfire/test/files/data_function/table_metadata.txt
+++ b/spotfire/test/files/data_function/table_metadata.txt
@@ -1,3 +1,3 @@
 
-Standard error:
+Warnings:
 <data_function>:3: UserWarning: Pandas doesn't allow columns to be created via a new attribute name - see https://pandas.pydata.org/pandas-docs/stable/indexing.html#attribute-access

--- a/spotfire/test/files/data_function/warning_per_row.txt
+++ b/spotfire/test/files/data_function/warning_per_row.txt
@@ -1,7 +1,7 @@
 
 Warnings:
-<data_function>:3: UserWarning: bad value at row 0
-<data_function>:3: UserWarning: bad value at row 1
-<data_function>:3: UserWarning: bad value at row 2
-<data_function>:3: UserWarning: bad value at row 3
-<data_function>:3: UserWarning: bad value at row 4
+<data_function>:4: UserWarning: bad value at row 0
+<data_function>:4: UserWarning: bad value at row 1
+<data_function>:4: UserWarning: bad value at row 2
+<data_function>:4: UserWarning: bad value at row 3
+<data_function>:4: UserWarning: bad value at row 4

--- a/spotfire/test/files/data_function/warning_per_row.txt
+++ b/spotfire/test/files/data_function/warning_per_row.txt
@@ -1,0 +1,7 @@
+
+Warnings:
+<data_function>:3: UserWarning: bad value at row 0
+<data_function>:3: UserWarning: bad value at row 1
+<data_function>:3: UserWarning: bad value at row 2
+<data_function>:3: UserWarning: bad value at row 3
+<data_function>:3: UserWarning: bad value at row 4

--- a/spotfire/test/files/data_function/warning_pysrv79.txt
+++ b/spotfire/test/files/data_function/warning_pysrv79.txt
@@ -1,5 +1,5 @@
 
-Standard error:
+Warnings:
 <data_function>:4: Warning: This is a Warning
 <data_function>:5: UserWarning: This is a UserWarning
 <data_function>:6: DeprecationWarning: This is a DeprecationWarning

--- a/spotfire/test/test_data_function.py
+++ b/spotfire/test/test_data_function.py
@@ -272,15 +272,6 @@ warn("This is a BytesWarning", BytesWarning)
 warn("This is a ResourceWarning", ResourceWarning)""", {}, {}, True, expected,
                            has_warnings=True, has_stderr=False)
 
-    def test_warning_pandas(self):
-        """Test that pandas-generated warnings are captured separately from stderr."""
-        in1_df = pd.DataFrame({"a": [1.0, 2.0, 3.0]})
-        expected = _PythonVersionedExpectedValue("warning_pandas")
-        self._run_analytic("""import pandas as pd
-df = pd.DataFrame({"x": [1, 2, 3]})
-df.new_col = [4, 5, 6]
-output = in1""", {"in1": in1_df}, {"output": in1_df}, True, expected,
-                           has_warnings=True, has_stderr=False)
 
     def test_warning_per_row(self):
         """Test that per-row warnings are deduplicated by Python's default filter."""

--- a/spotfire/test/test_data_function.py
+++ b/spotfire/test/test_data_function.py
@@ -44,7 +44,8 @@ class DataFunctionTest(unittest.TestCase):
     """Unit tests for public functions in 'spotfire.data_function' module."""
     # pylint: disable=too-many-branches, too-many-statements, too-many-arguments, too-many-public-methods
 
-    def _run_analytic(self, script, inputs, outputs, success, expected_result, spec_adjust=None) -> None:
+    def _run_analytic(self, script, inputs, outputs, success, expected_result, spec_adjust=None,
+                       has_warnings=None, has_stderr=None) -> None:
         """Run a full pass through the analytic protocol, and compare the output to the expected value."""
         # pylint: disable=too-many-positional-arguments,protected-access,too-many-locals
         with _utils.TempFiles() as temp_files:
@@ -106,6 +107,10 @@ class DataFunctionTest(unittest.TestCase):
             if not actual_result.success:
                 print("test: data function has failed")
             self.assertEqual(actual_result.success, success)
+            if has_warnings is not None:
+                self.assertEqual(actual_result.has_warnings, has_warnings)
+            if has_stderr is not None:
+                self.assertEqual(actual_result.has_stderr, has_stderr)
             print("test: done evaluating spec")
 
             for output in output_spec:
@@ -249,7 +254,7 @@ x = a*b
 print("But not this.")""", {}, {}, False, expected)
 
     def test_warning_pysrv79(self):
-        """Test that warnings are returned."""
+        """Test that warnings are returned separately from stderr."""
         expected = _PythonVersionedExpectedValue("warning_pysrv79")
         self._run_analytic("""import warnings
 warnings.simplefilter("always")
@@ -264,7 +269,48 @@ warn("This is a PendingDeprecationWarning", PendingDeprecationWarning)
 warn("This is a ImportWarning", ImportWarning)
 warn("This is a UnicodeWarning", UnicodeWarning)
 warn("This is a BytesWarning", BytesWarning)
-warn("This is a ResourceWarning", ResourceWarning)""", {}, {}, True, expected)
+warn("This is a ResourceWarning", ResourceWarning)""", {}, {}, True, expected,
+                           has_warnings=True, has_stderr=False)
+
+    def test_warning_pandas(self):
+        """Test that pandas-generated warnings are captured separately from stderr."""
+        in1_df = pd.DataFrame({"a": [1.0, 2.0, 3.0]})
+        expected = _PythonVersionedExpectedValue("warning_pandas")
+        self._run_analytic("""import pandas as pd
+df = pd.DataFrame({"x": [1, 2, 3]})
+df.new_col = [4, 5, 6]
+output = in1""", {"in1": in1_df}, {"output": in1_df}, True, expected,
+                           has_warnings=True, has_stderr=False)
+
+    def test_warning_per_row(self):
+        """Test that per-row warnings are deduplicated by Python's default filter."""
+        in1_df = pd.DataFrame({"a": pd.array([1, 2, 3, 4, 5], dtype="Int64")})
+        expected = _PythonVersionedExpectedValue("warning_per_row")
+        self._run_analytic("""import warnings
+for idx, row in in1.iterrows():
+    warnings.warn(f"bad value at row {idx}")
+output = in1""", {"in1": in1_df}, {"output": in1_df}, True, expected,
+                           has_warnings=True, has_stderr=False)
+
+    def test_warning_truncated(self):
+        """Test that warnings are truncated to _MAX_WARNINGS."""
+        spec = datafn.AnalyticSpec("script", [], [], """import warnings
+warnings.simplefilter("always")
+for i in range(150):
+    warnings.warn(f"warning {i}")""")
+        result = spec.evaluate()
+        self.assertTrue(result.has_warnings)
+        self.assertEqual(len(result.warnings), 101)
+        self.assertIn("50 more warnings (truncated)", result.warnings[-1])
+
+    def test_warning_suppressed(self):
+        """Test that warnings.simplefilter('ignore') suppresses warning capture."""
+        self._run_analytic("""import warnings
+warnings.simplefilter("ignore")
+import pandas as pd
+df = pd.DataFrame({"x": [1, 2, 3]})
+df.new_col = [4, 5, 6]""", {}, {}, True, None,
+                           has_warnings=False, has_stderr=False)
 
     def test_stderr_pysrv116(self):
         """Test that stdout is returned correctly with stderr"""

--- a/spotfire/test/test_data_function.py
+++ b/spotfire/test/test_data_function.py
@@ -274,10 +274,11 @@ warn("This is a ResourceWarning", ResourceWarning)""", {}, {}, True, expected,
 
 
     def test_warning_per_row(self):
-        """Test that per-row warnings are deduplicated by Python's default filter."""
+        """Test that unique per-row warnings are each captured individually."""
         in1_df = pd.DataFrame({"a": pd.array([1, 2, 3, 4, 5], dtype="Int64")})
         expected = _PythonVersionedExpectedValue("warning_per_row")
         self._run_analytic("""import warnings
+warnings.simplefilter("always")
 for idx, row in in1.iterrows():
     warnings.warn(f"bad value at row {idx}")
 output = in1""", {"in1": in1_df}, {"output": in1_df}, True, expected,

--- a/spotfire/test/test_data_function.py
+++ b/spotfire/test/test_data_function.py
@@ -292,8 +292,8 @@ for i in range(150):
     warnings.warn(f"warning {i}")""")
         result = spec.evaluate()
         self.assertTrue(result.has_warnings)
-        self.assertEqual(len(result.warnings), 101)
-        self.assertIn("50 more warnings (truncated)", result.warnings[-1])
+        self.assertEqual(len(result.warnings), 100)
+        self.assertIn("51 more warnings (truncated)", result.warnings[-1])
 
     def test_warning_suppressed(self):
         """Test that warnings.simplefilter('ignore') suppresses warning capture."""

--- a/spotfire/test/test_sbdf.py
+++ b/spotfire/test/test_sbdf.py
@@ -445,7 +445,8 @@ class SbdfTest(unittest.TestCase):
         }
         for resolution, timestamp in inputs.items():
             with self.subTest(resolution=resolution):
-                array = np.array([[0], [timestamp]]).astype(f"datetime64[{resolution}]")
+                array: np.ndarray = np.array([[0], [timestamp]])
+                array = array.astype(f"datetime64[{resolution}]")
                 dataframe = pd.DataFrame(array, columns=["x"])
                 df2 = self._roundtrip_dataframe(dataframe)
                 val = df2.at[1, 'x']
@@ -462,7 +463,8 @@ class SbdfTest(unittest.TestCase):
         }
         for resolution, timestamp in inputs.items():
             with self.subTest(resolution=resolution):
-                array = np.array([[0], [timestamp]]).astype(f"timedelta64[{resolution}]")
+                array: np.ndarray = np.array([[0], [timestamp]])
+                array = array.astype(f"timedelta64[{resolution}]")
                 dataframe = pd.DataFrame(array, columns=["x"])
                 df2 = self._roundtrip_dataframe(dataframe)
                 val = df2.at[1, 'x']


### PR DESCRIPTION
Previously, warnings were written to the standard error stream. A new warnings field has now been added to AnalyticResult so that warnings can be returned separately instead of being mixed with standard error output.